### PR TITLE
Update cache key and working_directory

### DIFF
--- a/src/commands/download.yml
+++ b/src/commands/download.yml
@@ -1,12 +1,16 @@
 description: Download Redmine << parameters.redmine_version >>
 parameters:
+  cache_key_prefix:
+    description: prefix of cache key
+    type: string
+    default: redmine-plugin-commands-download
   redmine_version:
     description: version of Redmine
     type: string
 steps:
   - restore_cache:
       keys:
-        - '{{ .Environment.CACHE_VERSION }}-redmine-download-<< parameters.redmine_version >>'
+        - '<< parameters.cache_key_prefix >>-<< parameters.redmine_version >>'
   - run:
       name: Download Redmine << parameters.redmine_version >>
       working_directory: '~/'
@@ -16,5 +20,5 @@ steps:
           curl https://redmine.org/releases/redmine-<< parameters.redmine_version >>.tar.gz | tar zx
         fi
   - save_cache:
-      key: '{{ .Environment.CACHE_VERSION }}-redmine-download-<< parameters.redmine_version >>'
+      key: '<< parameters.cache_key_prefix >>-<< parameters.redmine_version >>'
       paths: ~/redmine-<< parameters.redmine_version >>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,35 +1,33 @@
 description: Setup Redmine
 parameters:
-  db:
-    description: Database
+  cache_key:
+    description: key of cache
     type: string
-  redmine_version:
-    description: version of Redmine
-    type: string
-  ruby_version:
-    description: version of Ruby
+    default: redmine-plugin-commands-setup
+  working_directory:
+    description: Redmine root directory
     type: string
 steps:
   - restore_cache:
       keys:
-        - '{{ .Environment.CACHE_VERSION }}-redmine-setup-<< parameters.ruby_version >>-<< parameters.redmine_version >>-<< parameters.db >>-{{ checksum "Gemfile.local" }}'
+        - '<< parameters.cache_key >>'
   - run:
-      name: Setup Redmine << parameters.redmine_version >>
-      working_directory: ~/redmine-<< parameters.redmine_version >>
+      name: Setup Redmine
+      working_directory: << parameters.working_directory >>
       command: |
         bundle check || bundle install --without development rmagick
   - save_cache:
-      key: '{{ .Environment.CACHE_VERSION }}-redmine-setup-<< parameters.ruby_version >>-<< parameters.redmine_version >>-<< parameters.db >>-{{ checksum "Gemfile.local" }}'
+      key: '<< parameters.cache_key >>'
       paths:
         - ~/.bundle
-        - ~/redmine-<< parameters.redmine_version >>/Gemfile.lock
+        - << parameters.working_directory >>/Gemfile.lock
   - run:
       name: Setup Database
-      working_directory: ~/redmine-<< parameters.redmine_version >>
+      working_directory: << parameters.working_directory >>
       command: |
         bundle exec rake db:create db:migrate
   - run:
       name: Setup plugins
-      working_directory: ~/redmine-<< parameters.redmine_version >>
+      working_directory: << parameters.working_directory >>
       command: |
         bundle exec rake redmine:plugins


### PR DESCRIPTION
- Remove `CACHE_VERSION` environment variable from key from download command
- Remove db/redmine_version/ruby_version parameter from setup command
- Add `cache_key_prefix` parameter for download command
- Add `cache_key` parameter for setup command
- Add `working_directory` parameter for setup command