### PR TITLE
Remove unnecessary environment variables

### DIFF
--- a/src/executors/ruby-mysql.yml
+++ b/src/executors/ruby-mysql.yml
@@ -9,6 +9,3 @@ parameters:
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
   - image: circleci/mysql:<< parameters.mysql_version >>
-    environment:
-      - MYSQL_ALLOW_EMPTY_PASSWORD: true
-      - MYSQL_ROOT_HOST: '%'


### PR DESCRIPTION
It set already.

```
% docker run -it circleci/mysql bash
root@ec285580f57c:/# echo $MYSQL_ALLOW_EMPTY_PASSWORD
true
root@ec285580f57c:/# echo $MYSQL_ROOT_HOST
%
```

c.f. https://hub.docker.com/r/circleci/mysql