### PR TITLE
Fix download job

### DIFF
--- a/src/executors/downloader.yml
+++ b/src/executors/downloader.yml
@@ -1,2 +1,2 @@
 docker:
-  - image: circleci/ruby
+  - image: buildpack-deps:stretch-scm


### PR DESCRIPTION
circleci/ruby:latest is Debian buster now.

In Debian buster, I couldn't download the redmine.
http://www.redmine.org/issues/31755

So I change the executor to buildpack-deps:stretch-scm

- To fix curl error
- download job needs curl/svn commands only, we don't need ruby