### PR TITLE
Create empty Gemfile to generate cache_key_prefix correctly

### DIFF
--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -46,6 +46,7 @@ steps:
         else
           ln -s /tmp/plugin plugins/$CIRCLE_PROJECT_REPONAME
         fi
+        touch /tmp/plugin/Gemfile
   - steps: << parameters.before-setup >>
   - setup:
       cache_key_prefix: << parameters.cache_key_prefix >>{{ checksum "/tmp/plugin/Gemfile" }}


### PR DESCRIPTION
If plugin doesn't have Gemfile, line 52 of  `src/jobs/test.yml`: `{{ checksum "/tmp/plugin/Gemfile" }}` fail.