### PR TITLE
Add generate_database_yml command and generate database.yml automatically in test/rspec job

### DIFF
--- a/src/commands/generate_database_yml.yml
+++ b/src/commands/generate_database_yml.yml
@@ -1,0 +1,33 @@
+description: Generate database.yml
+steps:
+  - run:
+      name: Generate database.yml
+      command: |
+        if [ $DATABASE_ADAPTER = "mysql2" ]; then
+          cat \<<-'EOF' > config/database.yml
+          test:
+            adapter: mysql2
+            database: circle_test
+            host: 127.0.0.1
+            username: root
+            password:
+            encoding: utf8mb4
+        EOF
+        fi
+        if [ $DATABASE_ADAPTER = "postgresql" ]; then
+          cat \<<-'EOF' > config/database.yml
+          test:
+            adapter: postgresql
+            database: circle_test
+            host: 127.0.0.1
+            username: postgres
+            password: postgres
+        EOF
+        fi
+        if [ $DATABASE_ADAPTER = "sqlite3" ]; then
+          cat \<<-'EOF' > config/database.yml
+          test:
+            adapter: sqlite3
+            database: db/test.sqlite3
+        EOF
+        fi

--- a/src/executors/ruby-19-mysql.yml
+++ b/src/executors/ruby-19-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:1.9
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-19-pg.yml
+++ b/src/executors/ruby-19-pg.yml
@@ -8,4 +8,3 @@ docker:
     environment:
       DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>
-  

--- a/src/executors/ruby-19-pg.yml
+++ b/src/executors/ruby-19-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:1.9
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-20-mysql.yml
+++ b/src/executors/ruby-20-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.0
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-20-pg.yml
+++ b/src/executors/ruby-20-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:2.0
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-21-mysql.yml
+++ b/src/executors/ruby-21-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.1
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-21-pg.yml
+++ b/src/executors/ruby-21-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:2.1
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-22-mysql.yml
+++ b/src/executors/ruby-22-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.2
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-22-pg.yml
+++ b/src/executors/ruby-22-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:2.2
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-23-mysql.yml
+++ b/src/executors/ruby-23-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.3
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-23-pg.yml
+++ b/src/executors/ruby-23-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:2.3
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-24-mysql.yml
+++ b/src/executors/ruby-24-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.4
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-24-pg.yml
+++ b/src/executors/ruby-24-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: '9'
 docker:
   - image: circleci/ruby:2.4
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-25-mysql.yml
+++ b/src/executors/ruby-25-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.5
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-25-pg.yml
+++ b/src/executors/ruby-25-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.5
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-26-mysql.yml
+++ b/src/executors/ruby-26-mysql.yml
@@ -5,5 +5,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.6
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-26-pg.yml
+++ b/src/executors/ruby-26-pg.yml
@@ -5,4 +5,6 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:2.6
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-mysql.yml
+++ b/src/executors/ruby-mysql.yml
@@ -9,5 +9,7 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+    environment:
+      DATABASE_ADAPTER: mysql2
   - image: circleci/mysql:<< parameters.mysql_version >>-ram
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-pg.yml
+++ b/src/executors/ruby-pg.yml
@@ -9,4 +9,6 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+    environment:
+      DATABASE_ADAPTER: postgresql
   - image: circleci/postgres:<< parameters.pg_version >>-ram

--- a/src/executors/ruby-sqlite3.yml
+++ b/src/executors/ruby-sqlite3.yml
@@ -5,3 +5,5 @@ parameters:
     default: latest
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+    environment:
+      DATABASE_ADAPTER: sqlite3

--- a/src/jobs/rspec.yml
+++ b/src/jobs/rspec.yml
@@ -55,6 +55,7 @@ steps:
           REDMINE_PLUGIN_NAME=$CIRCLE_PROJECT_REPONAME
         fi
         ln -s /tmp/plugin plugins/$REDMINE_PLUGIN_NAME
+  - generate_database_yml
   - steps: << parameters.before-setup >>
   - setup:
       cache_key_prefix: << parameters.cache_key_prefix >>{{ checksum "/tmp/plugin/Gemfile" }}

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -53,6 +53,7 @@ steps:
         fi
         ln -s /tmp/plugin plugins/$REDMINE_PLUGIN_NAME
         touch /tmp/plugin/Gemfile
+  - generate_database_yml
   - steps: << parameters.before-setup >>
   - setup:
       cache_key_prefix: << parameters.cache_key_prefix >>{{ checksum "/tmp/plugin/Gemfile" }}


### PR DESCRIPTION
Redue generate database yml command in `before-setup`.

## before

```yaml
# .circleci/config.yml
version: 2.1

orbs:
  redmine: agileware-jp/redmine-plugin@0.0.11

workflows:
  version: 2
  test:
    jobs:
      - redmine/download:
          name: redmine40-download
          redmine_version: '4.0.4'
      - redmine/test:
          name: redmine40-mysql
          before-setup: [redmine/generate_database_yml-mysql]
          executor: redmine/ruby-mysql
          requires: [redmine40-download]
      - redmine/test:
          name: redmine40-pg
          before-setup: [redmine/generate_database_yml-pg]
          executor: redmine/ruby-pg
          requires: [redmine40-download]
      - redmine/test:
          name: redmine40-sqlite3
          before-setup: [redmine/generate_database_yml-sqlite3]
          executor: redmine/ruby-sqlite3
          requires: [redmine40-download]
```

## after

```yaml
# .circleci/config.yml
version: 2.1

orbs:
  redmine: agileware-jp/redmine-plugin@dev:a4f71d8

workflows:
  version: 2
  test:
    jobs:
      - redmine/download:
          name: redmine40-download
          redmine_version: '4.0.4'
      - redmine/test:
          name: redmine40-mysql
          executor: redmine/ruby-mysql
          requires: [redmine40-download]
      - redmine/test:
          name: redmine40-pg
          executor: redmine/ruby-pg
          requires: [redmine40-download]
      - redmine/test:
          name: redmine40-sqlite3
          executor: redmine/ruby-sqlite3
          requires: [redmine40-download]
```