### PR TITLE
Update bundle install path from vendor/bundle -> .bundle

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -15,11 +15,11 @@ steps:
   - run:
       name: Setup Redmine
       command: |
-        bundle check --path vendor/bundle || bundle install --path vendor/bundle
+        bundle check --path .bundle || bundle install --path .bundle
   - save_cache:
       key: '<< parameters.cache_key_prefix >>{{ checksum "/tmp/ruby-version" }}-{{ checksum "Gemfile" }}-{{ checksum "config/database.yml" }}'
       paths:
-        - vendor/bundle
+        - .bundle
         - Gemfile.lock
   - run:
       name: Setup Database


### PR DESCRIPTION
Change bundle install path to `.bundle` to make it easer to create a git commit on CircleCI.
`.bundle` directory is in `.gitignore` but `vendor/bundle` is not.