### PR TITLE
Enable to run RSpec more than once [semver:patch]

### DIFF
--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -54,7 +54,7 @@ steps:
           PLUGIN_NAME=$CIRCLE_PROJECT_REPONAME
         fi
 
-        echo $PLUGIN_NAME >> .tested_plugin
+        echo $PLUGIN_NAME > .tested_plugin
   - run:
       working_directory: '<< parameters.redmine_root >>'
       command: |

--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -32,7 +32,7 @@ steps:
   - run:
       name: Initialize RSpec
       working_directory: '<< parameters.redmine_root >>'
-      command: RAILS_ENV=test bundle exec rails generate rspec:install
+      command: RAILS_ENV=test bundle exec rails generate rspec:install --force
   - when:
       condition: << parameters.test_result_path  >>
       steps:


### PR DESCRIPTION
Sometimes we want to run RSpec more than once in one job (for example, run RSpec with other plugins and then rerun without other plugins).

This PR fixes some non-idempotent commands and enable to run RSpec more than once.