### PR TITLE
Add build-plugin-assets command [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,8 @@ workflows:
       - test-generate-database_yml
       - test-bundle-install-and-rspec
       - test-bundle-install-and-test
+      - test-build-plugin-assets
+      - test-build-plugin-assets-with-docker
 
       # publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
@@ -217,6 +219,8 @@ workflows:
             - test-generate-database_yml
             - test-bundle-install-and-rspec
             - test-bundle-install-and-test
+            - test-build-plugin-assets
+            - test-build-plugin-assets-with-docker
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,56 @@ jobs: # Integration Testing jobs
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
           plugin: redmine_issues_tree
+  test-build-plugin-assets:
+    docker:
+      - image: circleci/node:12.18.2
+    steps:
+      - run:
+          name: Create package.json that just creates a assets/test.js
+          command: |
+            cat \<<-'EOF' > package.json
+            {
+              "name": "test",
+              "version": "1.0.0",
+              "license": "MIT",
+              "scripts": {
+                "build": "mdkir assets && touch assets/test.js",
+              },
+            }
+          EOF
+            yarn install # Generate yarn.lock
+            rm -rf node_modules
+      - redmine-plugin/build-plugin-assets:
+          plugin_folder: '~/project'
+          cache_key_prefix: build-without-docker
+      - run:
+          name: Check if the built file exists
+          command: test -f ~/project/assets/test.js
+  test-build-plugin-assets-with-docker:
+    machine: true
+    steps:
+      - run:
+          name: Create package.json that just creates a assets/test.js
+          command: |
+            cat \<<-'EOF' > package.json
+            {
+              "name": "test",
+              "version": "1.0.0",
+              "license": "MIT",
+              "scripts": {
+                "build": "mdkir assets && touch assets/test.js",
+              },
+            }
+          EOF
+            yarn install # Generate yarn.lock
+            rm -rf node_modules
+      - redmine-plugin/build-plugin-assets:
+          plugin_folder: '~/project'
+          use_docker: true
+          cache_key_prefix: build-with-docker
+      - run:
+          name: Check if the built file exists
+          command: test -f ~/project/assets/test.js
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs: # Integration Testing jobs
                 "version": "1.0.0",
                 "license": "MIT",
                 "scripts": {
-                  "build": "mdkir assets && touch assets/test.js"
+                  "build": "mkdir assets && touch assets/test.js"
                 }
               }
             EOF
@@ -153,7 +153,7 @@ jobs: # Integration Testing jobs
                 "version": "1.0.0",
                 "license": "MIT",
                 "scripts": {
-                  "build": "mdkir assets && touch assets/test.js"
+                  "build": "mkdir assets && touch assets/test.js"
                 }
               }
             EOF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,15 +124,15 @@ jobs: # Integration Testing jobs
           name: Create package.json that just creates a assets/test.js
           command: |
             cat \<<-'EOF' > package.json
-            {
-              "name": "test",
-              "version": "1.0.0",
-              "license": "MIT",
-              "scripts": {
-                "build": "mdkir assets && touch assets/test.js",
-              },
-            }
-          EOF
+              {
+                "name": "test",
+                "version": "1.0.0",
+                "license": "MIT",
+                "scripts": {
+                  "build": "mdkir assets && touch assets/test.js",
+                },
+              }
+            EOF
             yarn install # Generate yarn.lock
             rm -rf node_modules
       - redmine-plugin/build-plugin-assets:
@@ -148,15 +148,15 @@ jobs: # Integration Testing jobs
           name: Create package.json that just creates a assets/test.js
           command: |
             cat \<<-'EOF' > package.json
-            {
-              "name": "test",
-              "version": "1.0.0",
-              "license": "MIT",
-              "scripts": {
-                "build": "mdkir assets && touch assets/test.js",
-              },
-            }
-          EOF
+              {
+                "name": "test",
+                "version": "1.0.0",
+                "license": "MIT",
+                "scripts": {
+                  "build": "mdkir assets && touch assets/test.js",
+                },
+              }
+            EOF
             yarn install # Generate yarn.lock
             rm -rf node_modules
       - redmine-plugin/build-plugin-assets:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,21 +120,10 @@ jobs: # Integration Testing jobs
     docker:
       - image: circleci/node:12.18.2
     steps:
+      - checkout
       - run:
-          name: Create package.json that just creates a assets/test.js
-          command: |
-            cat \<<-'EOF' > package.json
-              {
-                "name": "test",
-                "version": "1.0.0",
-                "license": "MIT",
-                "scripts": {
-                  "build": "mkdir assets && touch assets/test.js"
-                }
-              }
-            EOF
-            echo '12.18.2' > .node-version
-            touch yarn.lock
+          name: Set .node-version
+          command: echo '12.18.2' > .node-version
       - redmine-plugin/build-plugin-assets:
           plugin_folder: '~/project'
           cache_key_prefix: build-without-docker
@@ -144,21 +133,10 @@ jobs: # Integration Testing jobs
   test-build-plugin-assets-with-docker:
     machine: true
     steps:
+      - checkout
       - run:
-          name: Create package.json that just creates a assets/test.js
-          command: |
-            cat \<<-'EOF' > package.json
-              {
-                "name": "test",
-                "version": "1.0.0",
-                "license": "MIT",
-                "scripts": {
-                  "build": "mkdir assets && touch assets/test.js"
-                }
-              }
-            EOF
-            echo '12.18.2' > .node-version
-            touch yarn.lock
+          name: Set .node-version
+          command: echo '12.18.2' > .node-version
       - redmine-plugin/build-plugin-assets:
           plugin_folder: '~/project'
           use_docker: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ jobs: # Integration Testing jobs
                 "version": "1.0.0",
                 "license": "MIT",
                 "scripts": {
-                  "build": "mdkir assets && touch assets/test.js",
-                },
+                  "build": "mdkir assets && touch assets/test.js"
+                }
               }
             EOF
             yarn install # Generate yarn.lock
@@ -153,8 +153,8 @@ jobs: # Integration Testing jobs
                 "version": "1.0.0",
                 "license": "MIT",
                 "scripts": {
-                  "build": "mdkir assets && touch assets/test.js",
-                },
+                  "build": "mdkir assets && touch assets/test.js"
+                }
               }
             EOF
             yarn install # Generate yarn.lock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs: # Integration Testing jobs
                 }
               }
             EOF
+            echo '12.18.2' > .node-version
             yarn install # Generate yarn.lock
             rm -rf node_modules
       - redmine-plugin/build-plugin-assets:
@@ -157,6 +158,7 @@ jobs: # Integration Testing jobs
                 }
               }
             EOF
+            echo '12.18.2' > .node-version
             yarn install # Generate yarn.lock
             rm -rf node_modules
       - redmine-plugin/build-plugin-assets:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,8 +134,7 @@ jobs: # Integration Testing jobs
               }
             EOF
             echo '12.18.2' > .node-version
-            yarn install # Generate yarn.lock
-            rm -rf node_modules
+            touch yarn.lock
       - redmine-plugin/build-plugin-assets:
           plugin_folder: '~/project'
           cache_key_prefix: build-without-docker
@@ -159,8 +158,7 @@ jobs: # Integration Testing jobs
               }
             EOF
             echo '12.18.2' > .node-version
-            yarn install # Generate yarn.lock
-            rm -rf node_modules
+            touch yarn.lock
       - redmine-plugin/build-plugin-assets:
           plugin_folder: '~/project'
           use_docker: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if Gemfile.local was copied
           command: test -f redmine/Gemfile.local
-
   test-generate-database_yml:
     executor: redmine-plugin/ruby-mysql
     steps:
@@ -77,7 +76,6 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if the correct database.yml was created
           command: 'egrep "adapter: mysql2" redmine/config/database.yml'
-
   test-bundle-install-and-rspec:
     executor:
       name: redmine-plugin/ruby-sqlite3

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "this_file_is_only_for_orb_testing",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "build": "mkdir assets && touch assets/test.js"
+  }
+}

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -10,22 +10,21 @@ parameters:
     type: string
 
 steps:
-  - run:
-      name: Determine commit for cache
-      working_directory: '<< parameters.plugin_folder >>'
-      command: git rev-parse HEAD > .commit
   - restore_cache:
       keys:
-        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
+        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'
+  - run:
+      name: Install dependencies
+      working_directory: '<< parameters.plugin_folder >>'
+      command: |
+        if [ ! -d node_modules ]; then
+          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn install
+        fi
+  - save_cache:
+      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'
+      paths:
+        - '<< parameters.plugin_folder >>/node_modules'
   - run:
       name: Build assets
       working_directory: '<< parameters.plugin_folder >>'
-      command: |
-        if [ ! -f assets/.build_finished ]; then
-          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` /bin/bash -c "yarn install && yarn build"
-          touch assets/.build_finished
-        fi
-  - save_cache:
-      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
-      paths:
-        - '<< parameters.plugin_folder >>/assets'
+      command: docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn build

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -4,7 +4,7 @@ parameters:
   cache_key_prefix:
     description: Prefix of cache key
     type: string
-    default: redmine-plugin-build-cache-
+    default: redmine-plugin-build-cache
   plugin_folder:
     description: Plugin folder
     type: string
@@ -20,7 +20,7 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
+        - '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
   - run:
       name: Install dependencies
       working_directory: '<< parameters.plugin_folder >>'
@@ -33,6 +33,21 @@ steps:
       paths:
         - '<< parameters.plugin_folder >>/node_modules'
   - run:
+      name: Determine commit for cache
+      working_directory: '<< parameters.plugin_folder >>'
+      command: git rev-parse HEAD > .commit
+  - restore_cache:
+      keys:
+        - '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
+  - run:
       name: Build assets
       working_directory: '<< parameters.plugin_folder >>'
-      command: <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
+      command: |
+        if [ ! -f assets/.build_finished ]; then
+          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
+          touch assets/.build_finished
+        fi
+  - save_cache:
+      key: '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
+      paths:
+        - '<< parameters.plugin_folder >>/assets'

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -44,7 +44,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -f assets/.build_finished ]; then
-          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
+          <<# parameters.use_docker >>docker run -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
           touch assets/.build_finished
         fi
   - save_cache:

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -44,7 +44,14 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -f assets/.build_finished ]; then
-          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version` /bin/bash -c<</ parameters.use_docker >> "yarn build && touch assets/.build_finished"
+          <<# parameters.use_docker >>export USE_DOCKER='1'<</ parameters.use_docker >>
+
+          if [ -n "${USE_DOCKER}" ]; then
+            docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version` /bin/bash -c "yarn build && touch assets/.build_finished"
+          else
+            yarn build
+            touch assets/.build_finished
+          fi
         fi
   - save_cache:
       key: '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -26,10 +26,10 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -d node_modules ]; then
-          <<# parameters.use_docker >>docker run -u root -v `pwd`:/home/circleci/plugin -w /home/circleci/plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
+          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
         fi
   - save_cache:
-      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
+      key: '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
       paths:
         - '<< parameters.plugin_folder >>/node_modules'
   - run:
@@ -44,8 +44,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -f assets/.build_finished ]; then
-          <<# parameters.use_docker >>docker run -v `pwd`:/home/circleci/plugin -w /home/circleci/plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
-          touch assets/.build_finished
+          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version` /bin/bash -c<</ parameters.use_docker >> "yarn build && touch assets/.build_finished"
         fi
   - save_cache:
       key: '<< parameters.cache_key_prefix >>-<< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -26,7 +26,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -d node_modules ]; then
-          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
+          <<# parameters.use_docker >>docker run -u root -v `pwd`:/home/circleci/plugin -w /home/circleci/plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
         fi
   - save_cache:
       key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
@@ -44,7 +44,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -f assets/.build_finished ]; then
-          <<# parameters.use_docker >>docker run -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
+          <<# parameters.use_docker >>docker run -v `pwd`:/home/circleci/plugin -w /home/circleci/plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build
           touch assets/.build_finished
         fi
   - save_cache:

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -1,0 +1,29 @@
+description: Run yarn build to build plugin assets (requires Docker)
+
+parameters:
+  cache_key_prefix:
+    description: Prefix of cache key
+    type: string
+    default: redmine-plugin-build-cache-
+  plugin_folder:
+    description: Plugin folder
+    type: string
+
+steps:
+  - run:
+      working_directory: '<< parameters.plugin_folder >>'
+      command: git rev-parse HEAD > .commit
+  - restore_cache:
+      keys:
+        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
+  - run:
+      working_directory: '<< parameters.plugin_folder >>'
+      command: |
+        if [ ! -f assets/.build_finished ]; then
+          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` /bin/bash -c "yarn install && yarn build"
+          touch assets/.build_finished
+        fi
+  - save_cache:
+      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
+      paths:
+        - '<< parameters.plugin_folder >>/assets'

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -11,12 +11,14 @@ parameters:
 
 steps:
   - run:
+      name: Determine commit for cache
       working_directory: '<< parameters.plugin_folder >>'
       command: git rev-parse HEAD > .commit
   - restore_cache:
       keys:
         - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.commit" }}'
   - run:
+      name: Build assets
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -f assets/.build_finished ]; then

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -18,7 +18,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -d node_modules ]; then
-          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn install
+          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn install --frozen-lockfile
         fi
   - save_cache:
       key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -1,4 +1,4 @@
-description: Run yarn build to build plugin assets (requires Docker)
+description: Run yarn build to build plugin assets.
 
 parameters:
   cache_key_prefix:
@@ -8,6 +8,14 @@ parameters:
   plugin_folder:
     description: Plugin folder
     type: string
+  use_docker:
+    description: Should the build happen inside a docker container?
+    type: boolean
+    default: false
+  build_docker_container:
+    description: Container that should be used for building with docker (tag will be specified by `(plugin_folder)/.node-version`).
+    type: string
+    default: circleci/node
 
 steps:
   - restore_cache:
@@ -18,7 +26,7 @@ steps:
       working_directory: '<< parameters.plugin_folder >>'
       command: |
         if [ ! -d node_modules ]; then
-          docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn install --frozen-lockfile
+          <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
         fi
   - save_cache:
       key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'
@@ -27,4 +35,4 @@ steps:
   - run:
       name: Build assets
       working_directory: '<< parameters.plugin_folder >>'
-      command: docker run -u root -v `pwd`:/plugin -w /plugin circleci/node:`cat .node-version` yarn build
+      command: <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn build

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -20,7 +20,7 @@ parameters:
 steps:
   - restore_cache:
       keys:
-        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'
+        - '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
   - run:
       name: Install dependencies
       working_directory: '<< parameters.plugin_folder >>'
@@ -29,7 +29,7 @@ steps:
           <<# parameters.use_docker >>docker run -u root -v `pwd`:/plugin -w /plugin << parameters.build_docker_container >>:`cat .node-version`<</ parameters.use_docker >> yarn install --frozen-lockfile
         fi
   - save_cache:
-      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum ".node-version" }}-{{ checksum "yarn.lock" }}'
+      key: '<< parameters.cache_key_prefix >><< parameters.plugin_folder >>-{{ checksum "<< parameters.plugin_folder >>/.node-version" }}-{{ checksum "<< parameters.plugin_folder >>/yarn.lock" }}'
       paths:
         - '<< parameters.plugin_folder >>/node_modules'
   - run:

--- a/src/examples/redmine-plugin-rspec-with-build-assets.yml
+++ b/src/examples/redmine-plugin-rspec-with-build-assets.yml
@@ -1,0 +1,60 @@
+usage:
+  version: 2.1
+
+  orbs:
+    redmine: agileware-jp/redmine-plugin@x.y.z
+
+  jobs:
+    build:
+      docker:
+        - image: circleci/node:12.13.1
+      steps:
+        - checkout
+        - redmine-plugin/build-plugin-assets:
+            plugin_folder: '~/project'
+            # Use use_docker: true and a machine executor if you need to build in several different nodejs environments
+        - persist_to_workspace:
+            root: '~/project'
+            paths:
+              - assets
+    run-tests:
+      parameters:
+        redmine_version:
+          type: string
+        ruby_version:
+          type: string
+        database:
+          type: enum
+          enum: ['mysql', 'pg', 'mariadb', 'sqlite']
+      executor:
+        name: redmine-plugin/ruby-<< parameters.database >>
+        ruby_version: << parameters.ruby_version >>
+      steps:
+        - checkout
+        - redmine/download-redmine:
+            version: << parameters.redmine_version >>
+        - redmine/install-self
+        - attach_workspace:
+            at: ~/project/redmine/plugins/tested_plugin # Attach built assets
+        - redmine-plugin/generate-database_yml
+        - redmine-plugin/bundle-install
+        - redmine-plugin/rspec
+
+  workflows:
+    version: 2
+    test:
+      jobs:
+        - build
+        - run-tests:
+            redmine_version: '4.1.0'
+            ruby_version: '2.6'
+            database: 'pg'
+            requires:
+              - build
+        - run-tests:
+            redmine_version: '4.1.0'
+            ruby_version: '2.6'
+            database: 'mysql'
+            requires:
+              - build
+        # Add more configurations as you like

--- a/yarn.lock
+++ b/yarn.lock
@@ -1,0 +1,1 @@
+# Only for orb testing purposes


### PR DESCRIPTION
プラグインのassetをyarn build でビルドするコマンドです。
- yarn install と yarn build の結果は別々でキャッシュされる
- docker を使うかどうか、パラメーターで指定できる

testcafeだけではなく、普通の開発者テストにも普通に役に立ちそうです。