### PR TITLE
Fix orb examples

### DIFF
--- a/src/examples/redmine-plugin-rspec-with-build-assets.yml
+++ b/src/examples/redmine-plugin-rspec-with-build-assets.yml
@@ -2,7 +2,7 @@ usage:
   version: 2.1
 
   orbs:
-    redmine: agileware-jp/redmine-plugin@x.y.z
+    redmine-plugin: agileware-jp/redmine-plugin@x.y.z
 
   jobs:
     build:
@@ -31,9 +31,9 @@ usage:
         ruby_version: << parameters.ruby_version >>
       steps:
         - checkout
-        - redmine/download-redmine:
+        - redmine-plugin/download-redmine:
             version: << parameters.redmine_version >>
-        - redmine/install-self
+        - redmine-plugin/install-self
         - attach_workspace:
             at: ~/project/redmine/plugins/tested_plugin # Attach built assets
         - redmine-plugin/generate-database_yml

--- a/src/examples/redmine-plugin-rspec-with-build-assets.yml
+++ b/src/examples/redmine-plugin-rspec-with-build-assets.yml
@@ -25,7 +25,7 @@ usage:
           type: string
         database:
           type: enum
-          enum: ['mysql', 'pg', 'mariadb', 'sqlite']
+          enum: ['mysql', 'pg', 'mariadb', 'sqlite3']
       executor:
         name: redmine-plugin/ruby-<< parameters.database >>
         ruby_version: << parameters.ruby_version >>

--- a/src/examples/redmine-plugin-rspec.yml
+++ b/src/examples/redmine-plugin-rspec.yml
@@ -13,7 +13,7 @@ usage:
           type: string
         database:
           type: enum
-          enum: ['mysql', 'pg', 'mariadb', 'sqlite']
+          enum: ['mysql', 'pg', 'mariadb', 'sqlite3']
       executor:
         name: redmine-plugin/ruby-<< parameters.database >>
         ruby_version: << parameters.ruby_version >>

--- a/src/examples/redmine-plugin-rspec.yml
+++ b/src/examples/redmine-plugin-rspec.yml
@@ -2,7 +2,7 @@ usage:
   version: 2.1
 
   orbs:
-    redmine: agileware-jp/redmine-plugin@x.y.z
+    redmine-plugin: agileware-jp/redmine-plugin@x.y.z
 
   jobs:
     run-tests:
@@ -19,9 +19,9 @@ usage:
         ruby_version: << parameters.ruby_version >>
       steps:
         - checkout
-        - redmine/download-redmine:
+        - redmine-plugin/download-redmine:
             version: << parameters.redmine_version >>
-        - redmine/install-self
+        - redmine-plugin/install-self
         # Add dependent plugins here
         # - redmine-plugin/install-plugin:
         #     repository: git@github.com:my-company/super_plugin.git


### PR DESCRIPTION
Thank you for sharing a useful Orb.

When I wrote `.circleci/config.yml` using the [examples](https://github.com/agileware-jp/redmine-plugin-orb/tree/d273853f76e55ba20c43a9db11ec7a00ae81addc/src/examples) in this repository, the test didn't run well due to two issues.
* 1. There is a place where redmine-plugin is written even though the name when referring to orb is redmine. Error: `Cannot find orb 'redmine-plugin' looking for command named 'redmine-plugin/generate-database_yml'`
* 2. ['mysql','pg','mariadb','sqlite'] is written as a candidate for parameters.database, but actually you should write sqlite3 instead of sqlite. https://github.com/agileware-jp/redmine-plugin-orb/tree/master/src/executors

This merge request fixes two issues.

I'm using https://github.com/ishikawa999/redmine_message_customize/blob/07e140eeea207f8a36f43d83005d9851fbb2a15e/.circleci/config.yml written based on [examples](https://github.com/agileware-jp/redmine-plugin-orb/tree/d273853f76e55ba20c43a9db11ec7a00ae81addc/src/examples).