### PR TITLE
Use 'cimg' instead of 'circleci'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ version: 2.1
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.1.0
+  browser-tools: circleci/browser-tools@1.4.0
 
 # Pipeline parameters
 parameters:
@@ -172,7 +173,7 @@ jobs: # Integration Testing jobs
           plugin: redmine_issues_tree
   test-build-plugin-assets:
     docker:
-      - image: circleci/node:12.18.2
+      - image: cimg/node:12.18.2
     steps:
       - checkout
       - run:

--- a/src/commands/build-plugin-assets.yml
+++ b/src/commands/build-plugin-assets.yml
@@ -15,7 +15,7 @@ parameters:
   build_docker_container:
     description: Container that should be used for building with docker (tag will be specified by `(plugin_folder)/.node-version`).
     type: string
-    default: circleci/node
+    default: cimg/node
 
 steps:
   - restore_cache:

--- a/src/examples/redmine-plugin-rspec-with-build-assets.yml
+++ b/src/examples/redmine-plugin-rspec-with-build-assets.yml
@@ -7,7 +7,7 @@ usage:
   jobs:
     build:
       docker:
-        - image: circleci/node:12.13.1
+        - image: cimg/node:12.13.1
       steps:
         - checkout
         - redmine-plugin/build-plugin-assets:

--- a/src/executors/ruby-mariadb.yml
+++ b/src/executors/ruby-mariadb.yml
@@ -6,7 +6,7 @@ parameters:
   db_version:
     description: version of MariaDB
     type: string
-    default: latest-ram
+    default: "10.9"
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:

--- a/src/executors/ruby-mariadb.yml
+++ b/src/executors/ruby-mariadb.yml
@@ -11,4 +11,4 @@ docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:
       DATABASE_ADAPTER: mysql2
-  - image: circleci/mariadb:<< parameters.db_version >>
+  - image: cimg/mariadb:<< parameters.db_version >>

--- a/src/executors/ruby-mysql.yml
+++ b/src/executors/ruby-mysql.yml
@@ -6,7 +6,7 @@ parameters:
   db_version:
     description: version of MySQL
     type: string
-    default: latest-ram
+    default: "8.0"
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:

--- a/src/executors/ruby-mysql.yml
+++ b/src/executors/ruby-mysql.yml
@@ -11,5 +11,5 @@ docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:
       DATABASE_ADAPTER: mysql2
-  - image: circleci/mysql:<< parameters.db_version >>
+  - image: cimg/mysql:<< parameters.db_version >>
     command: mysqld --default-authentication-plugin=mysql_native_password

--- a/src/executors/ruby-pg.yml
+++ b/src/executors/ruby-pg.yml
@@ -11,6 +11,6 @@ docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:
       DATABASE_ADAPTER: postgresql
-  - image: circleci/postgres:<< parameters.db_version >>
+  - image: cimg/postgres:<< parameters.db_version >>
     environment:
       POSTGRES_PASSWORD: password

--- a/src/executors/ruby-pg.yml
+++ b/src/executors/ruby-pg.yml
@@ -6,7 +6,7 @@ parameters:
   db_version:
     description: version of PostgreSQL
     type: string
-    default: latest-ram
+    default: "15.0"
 docker:
   - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
     environment:


### PR DESCRIPTION
## 背景・意図

イメージ名が `circleci/` ではじまるイメージは非推奨になりました
そこで `cimg/` ではじまるイメージを使うように変更します

ref. 

- [Legacy Convenience Image Deprecation](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034)
- [次世代 CircleCI イメージへの移行](https://circleci.com/docs/ja/2.0/next-gen-migration-guide/)

## 内容

`cimg/` には `Ruby 2.4.5` がないので、Rubyは `circleci/ruby` を使います
~~`Node.js 12.13.1` の新しいイメージはまだリリースされていなかったので、`Node.js 12.13.0` を使うようにしています~~

`default` が `latest` になっていましたが、`latest` というタグがないイメージがあります
そこで以下のように指定しました

項目 | バージョン | 備考
--- | --- | ---
Ruby | latest | `circleci/ruby` を使うため、`latest` のままとする
MySQL | 8.0 | 8はRedmineが対応していない？
MariaDB | 10.9 | 10はRedmineが対応していない？
PostgreSQL | 15.0 | 

---

データベースは、2022-11-11時点の最新のバージョンを指定しました

`circleci/buildpack-deps` は `cimg/base` に変わりました

- [イメージ廃止 - 次世代 CircleCI イメージへの移行](https://circleci.com/docs/ja/next-gen-migration-guide/#deprecated-images)

`circleci/browser-tools` は、新しいイメージでブラウザテストを行うために必要なイメージです

- [ブラウザーテスト - 次世代 CircleCI イメージへの移行](https://circleci.com/docs/ja/next-gen-migration-guide/#browser-testing)