### PR TITLE
Support "latest" Redmine version and Redmica version [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,22 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat redmine/.version`" = "3.4.9"
+  test-download-redmine-latest:
+    executor: orb-tools/ubuntu
+    steps:
+      - redmine-plugin/download-redmine:
+          version: latest
+      - run:
+          name: Check if redmine exists
+          command: test -f redmine/lib/redmine.rb
+      - run:
+          name: Check if there is a .version file containing latest version
+          command: |
+            cat redmine/.version
+            test $(cat redmine/.version) = $(
+              curl -s https://api.github.com/repos/redmine/redmine/tags |
+              jq -r '.[0].name'
+            )
   test-download-redmica:
     executor: orb-tools/ubuntu
     steps:
@@ -52,6 +68,25 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat wrk/.version`" = "2.0.0"
+  test-download-redmica-latest:
+    executor: orb-tools/ubuntu
+    steps:
+      - redmine-plugin/download-redmine:
+          product: 'redmica'
+          version: latest
+          destination: 'wrk'
+      - run:
+          name: Check if redmica exists
+          command: egrep "module\s+RedMica" wrk/lib/redmine/version.rb
+      - run:
+          name: Check if there is a .version file containing latest version
+          command: |
+            cat wrk/.version
+            test $(cat wrk/.version) = $(
+              curl -s https://api.github.com/repos/redmica/redmica/tags |
+              jq -r '.[0].name' |
+              sed -e 's/^v//'
+            )
   test-download-redmine-trunk:
     docker:
       - image: circleci/buildpack-deps:stretch-scm
@@ -188,8 +223,10 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - test-download-redmine
+      - test-download-redmine-latest
       - test-download-redmine-trunk
       - test-download-redmica
+      - test-download-redmica-latest
       - test-install-plugin
       - test-install-self
       - test-generate-database_yml
@@ -211,8 +248,10 @@ workflows:
           publish-version-tag: false
           requires:
             - test-download-redmine
+            - test-download-redmine-latest
             - test-download-redmine-trunk
             - test-download-redmica
+            - test-download-redmica-latest
             - test-install-plugin
             - test-install-self
             - test-generate-database_yml

--- a/src/commands/download-redmine.yml
+++ b/src/commands/download-redmine.yml
@@ -8,6 +8,7 @@ parameters:
   version:
     description: Redmine version
     type: string
+    default: latest
   destination:
     description: Destination path
     type: string
@@ -19,9 +20,43 @@ parameters:
     default: "redmine"
 
 steps:
+  - when:
+      condition:
+        not:
+          equal: [ latest, << parameters.version >> ]
+      steps:
+        - run:
+            name: Create specified version file
+            command: |
+              echo << parameters.version >> > .version
+  - when:
+      condition:
+        and:
+          - equal: [ redmine, << parameters.product >> ]
+          - equal: [ latest, << parameters.version >> ]
+      steps:
+        - run:
+            name: Create latest Redmine version file
+            command: |
+              curl -s https://api.github.com/repos/redmine/redmine/tags |
+              jq -r '.[0].name' > .version
+              echo "$(cat .version) is latest Redmine version."
+  - when:
+      condition:
+        and:
+          - equal: [ redmica, << parameters.product >> ]
+          - equal: [ latest, << parameters.version >> ]
+      steps:
+        - run:
+            name: Create latest Redmica version file
+            command: |
+              curl -s https://api.github.com/repos/redmica/redmica/tags |
+              jq -r '.[0].name' |
+              sed -e 's/^v//' > .version
+              echo "$(cat .version) is latest Redmica version."
   - restore_cache:
       keys:
-        - '<< parameters.cache_key_prefix >><< parameters.version >>'
+        - '<< parameters.cache_key_prefix >><< parameters.product >>-<< parameters.version >>-{{ checksum ".version" }}'
   - when:
       condition:
         equal: [ redmine, << parameters.product >> ]
@@ -30,8 +65,12 @@ steps:
             name: Download << parameters.product >> << parameters.version >>
             command: |
               if [ ! -d << parameters.product >>-<< parameters.version >> ]; then
-                curl -L https://github.com/redmine/redmine/archive/<< parameters.version >>.tar.gz | tar zx
-                echo '<< parameters.version >>' > << parameters.product >>-<< parameters.version >>/.version
+                version="$(cat .version)"
+                curl -L "https://github.com/redmine/redmine/archive/$version.tar.gz" | tar zx
+                if [ "$version" != << parameters.version >> ]; then
+                  mv -v << parameters.product >>-"$version" << parameters.product >>-<< parameters.version >>
+                fi
+                cp -av .version << parameters.product >>-<< parameters.version >>/
               fi
   - when:
       condition:
@@ -42,11 +81,15 @@ steps:
             # https://github.com/redmica/redmica/archive/v2.0.0 # `v2.0.0` not `2.0.0`
             command: |
               if [ ! -d << parameters.product >>-<< parameters.version >> ]; then
-                curl -L https://github.com/redmica/redmica/archive/v<< parameters.version >>.tar.gz | tar zx
-                echo '<< parameters.version >>' > << parameters.product >>-<< parameters.version >>/.version
+                version="$(cat .version)"
+                curl -L "https://github.com/redmica/redmica/archive/v$version.tar.gz" | tar zx
+                if [ "$version" != << parameters.version >> ]; then
+                  mv -v << parameters.product >>-"$version" << parameters.product >>-<< parameters.version >>
+                fi
+                cp -av .version << parameters.product >>-<< parameters.version >>/
               fi
   - save_cache:
-      key: '<< parameters.cache_key_prefix >><< parameters.version >>'
+      key: '<< parameters.cache_key_prefix >><< parameters.product >>-<< parameters.version >>-{{ checksum ".version" }}'
       paths:
         - << parameters.product >>-<< parameters.version >>
   - run:


### PR DESCRIPTION
This pull-request gives us to use latest released Redmine version by following:

```yaml
- redmine-plugin/download-redmine:
    version: latest
```

And latest released Redmica version:

```yaml
- redmine-plugin/download-redmine:
    product: redmica
    version: latest
```
