### PR TITLE
Use cimg/ruby instead of circleci/ruby [semver:major]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,11 +157,11 @@ jobs: # Integration Testing jobs
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3
-      ruby_version: '2.4'
+      ruby_version: '2.5'
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '3.4.12'
+          version: '4.1.7'
       - redmine-plugin/install-plugin:
           repository: https://github.com/Loriowar/redmine_issues_tree.git
       - run:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -4,5 +4,9 @@ description: |
   Orbs for automated testing of plugins for Redmine (https://www.redmine.org/).
 
   Created and maintained by Agileware Inc. (https://agileware.jp/)
+
 display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
+
+orbs:
+  browser-tools: circleci/browser-tools@1.4.1

--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -19,6 +19,14 @@ steps:
       keys:
         - '<< parameters.cache_key_prefix >>{{ checksum "/tmp/ruby-version" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile.local" }}-{{ checksum "<< parameters.redmine_root >>/config/database.yml" }}'
   - run:
+      name: Install related packages
+      command: |
+        sudo apt-get update
+        if test "$DATABASE_ADAPTER" = sqlite3
+        then
+          sudo apt-get install -y libsqlite3-dev
+        fi
+  - run:
       name: Execute bundle install
       working_directory: '<< parameters.redmine_root >>'
       command: bundle check --path vendor/bundle || bundle install --path vendor/bundle

--- a/src/commands/download-redmine-trunk.yml
+++ b/src/commands/download-redmine-trunk.yml
@@ -21,7 +21,7 @@ steps:
       name: Download Redmine trunk
       command: |
         if [ ! -d redmine-trunk ]; then
-          svn co --non-interactive --config-option servers:global:ssl-authority-files=<(curl -sL https://www.gandi.net/static/CAs/GandiStandardSSLCA2.pem) https://svn.redmine.org/redmine/trunk redmine-trunk
+          svn co --non-interactive https://svn.redmine.org/redmine/trunk redmine-trunk
           echo 'trunk' > redmine-trunk/.version
         fi
   - save_cache:

--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -29,6 +29,8 @@ parameters:
     default: ''
 
 steps:
+  - browser-tools/install-chrome
+  - browser-tools/install-chromedriver
   - run:
       name: Setup Database
       working_directory: '<< parameters.redmine_root >>'

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -15,6 +15,8 @@ parameters:
     default: ''
 
 steps:
+  - browser-tools/install-chrome
+  - browser-tools/install-chromedriver
   - run:
       name: Setup Database
       working_directory: '<< parameters.redmine_root >>'

--- a/src/executors/ruby-mariadb.yml
+++ b/src/executors/ruby-mariadb.yml
@@ -2,13 +2,13 @@ parameters:
   ruby_version:
     description: version of Ruby
     type: string
-    default: latest
+    default: "3.2"
   db_version:
     description: version of MariaDB
     type: string
     default: "10.9"
 docker:
-  - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+  - image: cimg/ruby:<< parameters.ruby_version >>-browsers
     environment:
       DATABASE_ADAPTER: mysql2
   - image: cimg/mariadb:<< parameters.db_version >>

--- a/src/executors/ruby-mysql.yml
+++ b/src/executors/ruby-mysql.yml
@@ -2,14 +2,15 @@ parameters:
   ruby_version:
     description: version of Ruby
     type: string
-    default: latest
+    default: "3.2"
   db_version:
     description: version of MySQL
     type: string
     default: "8.0"
 docker:
-  - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+  - image: cimg/ruby:<< parameters.ruby_version >>-browsers
     environment:
       DATABASE_ADAPTER: mysql2
   - image: cimg/mysql:<< parameters.db_version >>
-    command: mysqld --default-authentication-plugin=mysql_native_password
+    command:
+      ["mysqld",  "--default-authentication-plugin=mysql_native_password", "--character-set-server=utf8mb4"]

--- a/src/executors/ruby-pg.yml
+++ b/src/executors/ruby-pg.yml
@@ -2,13 +2,13 @@ parameters:
   ruby_version:
     description: version of Ruby
     type: string
-    default: latest
+    default: "3.2"
   db_version:
     description: version of PostgreSQL
     type: string
     default: "15.0"
 docker:
-  - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+  - image: cimg/ruby:<< parameters.ruby_version >>-browsers
     environment:
       DATABASE_ADAPTER: postgresql
   - image: cimg/postgres:<< parameters.db_version >>

--- a/src/executors/ruby-sqlite3.yml
+++ b/src/executors/ruby-sqlite3.yml
@@ -2,8 +2,8 @@ parameters:
   ruby_version:
     description: version of Ruby
     type: string
-    default: latest
+    default: "3.2"
 docker:
-  - image: circleci/ruby:<< parameters.ruby_version >>-node-browsers
+  - image: cimg/ruby:<< parameters.ruby_version >>-browsers
     environment:
       DATABASE_ADAPTER: sqlite3


### PR DESCRIPTION
`circleci/ruby` is [deprecated](https://circleci.com/docs/next-gen-migration-guide/). and `circleci/ruby` doesn't have [ruby-3.0.4 and later](https://hub.docker.com/r/circleci/ruby/tags?page=1&name=3.). So, we must migrate to `cimg/ruby`.

Other `circleci/*` are migrated at #50 .
