### PR TITLE
Fix to support no Gemfile.local repositories [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,6 +300,8 @@ workflows:
             - test-download-redmine
             - test-download-redmine-latest
             - test-download-redmine-trunk
+            - test-download-redmine-supported-max-version
+            - test-download-redmine-supported-min-version
             - test-download-redmica
             - test-download-redmica-latest
             - test-install-plugin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs: # Integration Testing jobs
           command: test -f redmine/plugins/redmine-plugin-orb/src/@orb.yml
       - run:
           name: Check if Gemfile.local was copied
-          command: test -f redmine/Gemfile.local
+          command: diff -u redmine/plugins/redmine-plugin-orb/Gemfile.local redmine/Gemfile.local
   test-generate-database_yml:
     executor: redmine-plugin/ruby-mysql
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,19 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if the correct database.yml was created
           command: 'egrep "adapter: mysql2" redmine/config/database.yml'
+  test-bundle-install-without-Gemfile_local:
+    executor:
+      name: redmine-plugin/ruby-sqlite3
+      ruby_version: '2.6'
+    steps:
+      - checkout # To resolve ssh problems with git later
+      - redmine-plugin/download-redmine:
+          version: '4.1.5'
+      - redmine-plugin/generate-database_yml
+      - redmine-plugin/bundle-install
+      - run:
+          name: Check if Gemfile.local was created
+          command: test -f redmine/Gemfile.local
   test-bundle-install-and-rspec:
     executor:
       name: redmine-plugin/ruby-sqlite3
@@ -207,9 +220,6 @@ jobs: # Integration Testing jobs
           version: '4.1.7'
       - redmine-plugin/install-plugin:
           repository: https://github.com/Loriowar/redmine_issues_tree.git
-      - run:
-          name: Create Gemfile.local
-          command: touch redmine/Gemfile.local
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
@@ -280,6 +290,7 @@ workflows:
       - test-install-plugin
       - test-install-self
       - test-generate-database_yml
+      - test-bundle-install-without-Gemfile_local
       - test-bundle-install-and-rspec
       - test-bundle-install-and-test
       - test-build-plugin-assets
@@ -307,6 +318,7 @@ workflows:
             - test-install-plugin
             - test-install-self
             - test-generate-database_yml
+            - test-bundle-install-without-Gemfile_local
             - test-bundle-install-and-rspec
             - test-bundle-install-and-test
             - test-build-plugin-assets

--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -15,6 +15,11 @@ steps:
       name: Check ruby version
       command: |
         ruby -v > /tmp/ruby-version
+  - run:
+      name: Touch Gemfile.local if not exists
+      command: |
+        f="<< parameters.redmine_root >>/Gemfile.local"
+        test -e "$f" || touch "$f"
   - restore_cache:
       keys:
         - '<< parameters.cache_key_prefix >>{{ checksum "/tmp/ruby-version" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile.local" }}-{{ checksum "<< parameters.redmine_root >>/config/database.yml" }}'


### PR DESCRIPTION
https://github.com/agileware-jp/redmine-plugin-orb/blob/v3.1.0/src/commands/bundle-install.yml#L34 requires `Gemfile.local`. But some repositories does not include it.

https://github.com/agileware-jp/redmine-plugin-orb/pull/59/commits/42732ae1d200fcb3a2bd7133718e6cb663a7557e fixes it.
