### PR TITLE
Support latest tiny version [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,18 @@ jobs: # Integration Testing jobs
               egrep "MINOR.+${digits[1]}" redmine/lib/redmine/version.rb
               egrep "TINY.+${digits[2]}" redmine/lib/redmine/version.rb
             fi
+  test-download-redmine-latest-tiny-version:
+    executor: orb-tools/ubuntu
+    steps:
+      - redmine-plugin/download-redmine:
+          version: '4.1'
+      - run:
+          name: Check if redmine exists
+          command: test -f redmine/lib/redmine.rb
+      - run:
+          name: Check if there is a .version file containing latest version
+          command: |
+            test "$(cat redmine/.version)" = "4.1.7"
   test-download-redmica:
     executor: orb-tools/ubuntu
     steps:
@@ -131,6 +143,19 @@ jobs: # Integration Testing jobs
               jq -r '.[0].name' |
               sed -e 's/^v//'
             )
+  test-download-redmica-latest-tiny-version:
+    executor: orb-tools/ubuntu
+    steps:
+      - redmine-plugin/download-redmine:
+          product: 'redmica'
+          version: '2.1'
+      - run:
+          name: Check if redmine exists
+          command: test -f redmine/lib/redmine.rb
+      - run:
+          name: Check if there is a .version file containing latest version
+          command: |
+            test "$(cat redmine/.version)" = "2.1.1"
   test-download-redmine-trunk:
     docker:
       - image: circleci/buildpack-deps:stretch-scm
@@ -278,6 +303,7 @@ workflows:
     jobs:
       - test-download-redmine
       - test-download-redmine-latest
+      - test-download-redmine-latest-tiny-version
       - test-download-redmine-trunk
       - test-download-redmine-supported-max-version:
           context:
@@ -287,6 +313,7 @@ workflows:
             - lychee-ci-environment
       - test-download-redmica
       - test-download-redmica-latest
+      - test-download-redmica-latest-tiny-version
       - test-install-plugin
       - test-install-self
       - test-generate-database_yml
@@ -310,11 +337,13 @@ workflows:
           requires:
             - test-download-redmine
             - test-download-redmine-latest
+            - test-download-redmine-latest-tiny-version
             - test-download-redmine-trunk
             - test-download-redmine-supported-max-version
             - test-download-redmine-supported-min-version
             - test-download-redmica
             - test-download-redmica-latest
+            - test-download-redmica-latest-tiny-version
             - test-install-plugin
             - test-install-self
             - test-generate-database_yml

--- a/src/commands/download-redmine.yml
+++ b/src/commands/download-redmine.yml
@@ -25,13 +25,13 @@ steps:
       command: |
         extract_latest_redmine_version() {
           curl -s https://api.github.com/repos/redmine/redmine/tags |
-          jq -r '.[0].name' > .version
+          jq -r '.[0].name'
         }
 
         extract_latest_redmica_version() {
           curl -s https://api.github.com/repos/redmica/redmica/tags |
           jq -r '.[0].name' |
-          sed -e 's/^v//' > .version
+          sed -e 's/^v//'
         }
 
         version=<< parameters.version >>
@@ -40,11 +40,7 @@ steps:
         echo $version > .version
 
         if [ "$version" == "latest" ]; then
-          if [ "$product" == "redmine" ]; then
-            extract_latest_redmine_version
-          elif [ "$product" == "redmica" ]; then
-            extract_latest_redmica_version
-          fi
+          "extract_latest_${product}_version" > .version
         fi
 
         echo "Test product: << parameters.product >>@$(cat .version)"

--- a/src/commands/download-redmine.yml
+++ b/src/commands/download-redmine.yml
@@ -34,6 +34,21 @@ steps:
           sed -e 's/^v//'
         }
 
+        extract_latest_tiny_redmine_version() {
+          curl -s https://api.github.com/repos/redmine/redmine/tags |
+          jq -r '.[].name' |
+          grep "^$1" |
+          head -n1
+        }
+
+        extract_latest_tiny_redmica_version() {
+          curl -s https://api.github.com/repos/redmica/redmica/tags |
+          jq -r '.[].name' |
+          sed -e 's/^v//' |
+          grep "^$1" |
+          head -n1
+        }
+
         version=<< parameters.version >>
         product=<< parameters.product >>
 
@@ -41,6 +56,8 @@ steps:
 
         if [ "$version" == "latest" ]; then
           "extract_latest_${product}_version" > .version
+        elif [ -z "$(echo $version | cut -d . -f 3)" ]; then
+          "extract_latest_tiny_${product}_version" "$version" > .version
         fi
 
         echo "Test product: << parameters.product >>@$(cat .version)"


### PR DESCRIPTION
To use latest redmine-4.1.x:

```yaml
      - redmine-plugin/download-redmine:
          version: '4.1'
```

To use latest redmica-2.1.x:

```yaml
      - redmine-plugin/download-redmine:
          product: 'redmica'
          version: '2.1'
```
