### PR TITLE
fix: circleciのバージョン変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.1.0
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.3
 
 # Pipeline parameters
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,11 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat redmine/.version`" = "3.4.9"
+      - run:
+          name: Install and set Chrome version
+          command: |
+            curl -sSL https://raw.githubusercontent.com/CircleCI-Public/browser-tools/v1.4.3/scripts/install-browser-tools | bash
+            circleci-browser install chrome 114.0.5735.90
   test-download-redmine-supported-min-version:
     executor: orb-tools/ubuntu
     steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.2

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.2
+  browser-tools: circleci/browser-tools@1.4.3


### PR DESCRIPTION
### 変更内容
chromedriverのエンドポイントが変更され、installできなくなったことから、パッチ適用のため、browser-toolsのバージョンを1.4.1→1.4.3に変更

### 該当issue
https://github.com/CircleCI-Public/browser-tools-orb/issues/75