### PR TITLE
circleci browser tools from 1.4.1 to 1.4.3 [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,9 @@ jobs: # Integration Testing jobs
       - redmine-plugin/rspec:
           plugin: redmine_issue_templates
       - run:
+          name: Print current working directory
+          command: pwd
+      - run:
           name: Check if the test result file exists
           command: test -f /tmp/rspec/rspec.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,9 @@ jobs: # Integration Testing jobs
           version: '4.1.7'
       - redmine-plugin/install-plugin:
           repository: git@github.com:agileware-jp/redmine_issue_templates.git
+      - run:
+          name: Copy Gemfile.local
+          command: cp redmine/plugins/redmine_issue_templates/Gemfile.local redmine/
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ jobs: # Integration Testing jobs
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/test:
-          plugin: redmine_issues_tree
+          plugin: redmine_issue_templates
   test-build-plugin-assets:
     docker:
       - image: cimg/node:12.18.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs: # Integration Testing jobs
           repository: git@github.com:agileware-jp/redmine_issue_templates.git
       - run:
           name: Copy Gemfile.local
-          command: cp redmine/plugins/redmine_github/Gemfile.local redmine/
+          command: cp redmine/plugins/redmine_issue_templates/Gemfile.local redmine/
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/rspec:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,9 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if redmine has the downloaded version
           command: |
-            egrep "MAJOR.+3" redmine/lib/redmine/version.rb
-            egrep "MINOR.+4" redmine/lib/redmine/version.rb
-            egrep "TINY.+9" redmine/lib/redmine/version.rb
+            egrep "MAJOR.+4" redmine/lib/redmine/version.rb
+            egrep "MINOR.+1" redmine/lib/redmine/version.rb
+            egrep "TINY.+7" redmine/lib/redmine/version.rb
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat redmine/.version`" = "$REDMINE_MIN_VERSION"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,9 @@ jobs: # Integration Testing jobs
           name: Print current working directory
           command: pwd
       - run:
+          name: List contents of the current directory
+          command: ls -la
+      - run:
           name: Check if the test result file exists
           command: test -f /tmp/rspec/rspec.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ jobs: # Integration Testing jobs
           command: test -f /tmp/rspec/rspec.xml
       - run:
           name: Check if the coverage result file exists
-          command: test -f project/redmine/coverage/redmine_issue_templates_spec/index.html
+          command: test -f redmine/coverage/redmine_issue_templates_spec/index.html
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,8 +230,8 @@ jobs: # Integration Testing jobs
       - redmine-plugin/rspec:
           plugin: redmine_issue_templates
       - run:
-          name: Print current working directory
-          command: pwd
+          name: Change directory to redmine directory
+          command: cd redmine
       - run:
           name: List contents of the current directory
           command: ls -la
@@ -240,7 +240,7 @@ jobs: # Integration Testing jobs
           command: test -f /tmp/rspec/rspec.xml
       - run:
           name: Check if the coverage result file exists
-          command: test -f /coverage/redmine_issue_templates_spec/index.html
+          command: test -f /redmine/coverage/redmine_issue_templates_spec/index.html
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs: # Integration Testing jobs
       - redmine-plugin/download-redmine:
           version: '4.1.7'
       - redmine-plugin/install-plugin:
-          repository: git@github.com:agileware-jp/redmine_github.git
+          repository: git@github.com:agileware-jp/redmine_issue_templates.git
       - run:
           name: Copy Gemfile.local
           command: cp redmine/plugins/redmine_github/Gemfile.local redmine/
@@ -244,7 +244,7 @@ jobs: # Integration Testing jobs
       - redmine-plugin/download-redmine:
           version: '4.1.7'
       - redmine-plugin/install-plugin:
-          repository: https://github.com/Loriowar/redmine_issues_tree.git
+          repository: git@github.com:agileware-jp/redmine_issue_templates.git
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,11 +34,6 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat redmine/.version`" = "3.4.9"
-      - run:
-          name: Install and set Chrome version
-          command: |
-            curl -sSL https://raw.githubusercontent.com/CircleCI-Public/browser-tools/v1.4.3/scripts/install-browser-tools | bash
-            circleci-browser install chrome 114.0.5735.90
   test-download-redmine-supported-min-version:
     executor: orb-tools/ubuntu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs: # Integration Testing jobs
     executor: orb-tools/ubuntu
     steps:
       - redmine-plugin/download-redmine:
-          version: '3.4.9'
+          version: '$REDMINE_MIN_VERSION'
       - run:
           name: Check if redmine exists
           command: test -f redmine/lib/redmine.rb
@@ -33,7 +33,7 @@ jobs: # Integration Testing jobs
             egrep "TINY.+9" redmine/lib/redmine/version.rb
       - run:
           name: Check if there is a .version file containing the specified version
-          command: test "`cat redmine/.version`" = "3.4.9"
+          command: test "`cat redmine/.version`" = "$REDMINE_MIN_VERSION"
   test-download-redmine-supported-min-version:
     executor: orb-tools/ubuntu
     steps:
@@ -97,14 +97,14 @@ jobs: # Integration Testing jobs
     executor: orb-tools/ubuntu
     steps:
       - redmine-plugin/download-redmine:
-          version: '4.1'
+          version: '$REDMINE_MIN_VERSION'
       - run:
           name: Check if redmine exists
           command: test -f redmine/lib/redmine.rb
       - run:
           name: Check if there is a .version file containing latest version
           command: |
-            test "$(cat redmine/.version)" = "4.1.7"
+            test "$(cat redmine/.version)" = "$REDMINE_MIN_VERSION"
   test-download-redmica:
     executor: orb-tools/ubuntu
     steps:
@@ -172,7 +172,7 @@ jobs: # Integration Testing jobs
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '3.4.9'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/install-plugin:
           repository: git@github.com:agileware-jp/redmine_work_days.git
       - run:
@@ -182,7 +182,7 @@ jobs: # Integration Testing jobs
     executor: orb-tools/ubuntu
     steps:
       - redmine-plugin/download-redmine:
-          version: '3.4.9'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/install-self
       - run:
           name: Check if the repository was added to plugins
@@ -194,7 +194,7 @@ jobs: # Integration Testing jobs
     executor: redmine-plugin/ruby-mysql
     steps:
       - redmine-plugin/download-redmine:
-          version: '3.4.9'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/generate-database_yml
       - run:
           name: Check if the correct database.yml was created
@@ -304,9 +304,13 @@ workflows:
   test-and-release:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - test-download-redmine
+      - test-download-redmine:
+          context:
+            - lychee-ci-environment
       - test-download-redmine-latest
-      - test-download-redmine-latest-tiny-version
+      - test-download-redmine-latest-tiny-version:
+          context:
+            - lychee-ci-environment
       - test-download-redmine-trunk
       - test-download-redmine-supported-max-version:
           context:
@@ -317,9 +321,15 @@ workflows:
       - test-download-redmica
       - test-download-redmica-latest
       - test-download-redmica-latest-tiny-version
-      - test-install-plugin
-      - test-install-self
-      - test-generate-database_yml
+      - test-install-plugin:
+          context:
+            - lychee-ci-environment
+      - test-install-self:
+          context:
+            - lychee-ci-environment
+      - test-generate-database_yml:
+          context:
+            - lychee-ci-environment
       - test-bundle-install-without-Gemfile_local:
           context:
             - lychee-ci-environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ parameters:
     type: string
     default: "dev:alpha"
 
+common_environment: &common_environment
+  context:
+    - lychee-ci-environment
+
 jobs: # Integration Testing jobs
   test-download-redmine:
     executor: orb-tools/ubuntu
@@ -305,40 +309,30 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - test-download-redmine:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-download-redmine-latest
       - test-download-redmine-latest-tiny-version:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-download-redmine-trunk
       - test-download-redmine-supported-max-version:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-download-redmine-supported-min-version:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-download-redmica
       - test-download-redmica-latest
       - test-download-redmica-latest-tiny-version
       - test-install-plugin:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-install-self:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-generate-database_yml:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-bundle-install-without-Gemfile_local:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-bundle-install-and-rspec:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-bundle-install-and-test:
-          context:
-            - lychee-ci-environment
+          <<: *common_environment
       - test-build-plugin-assets
       - test-build-plugin-assets-with-docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs: # Integration Testing jobs
           command: test -f /tmp/rspec/rspec.xml
       - run:
           name: Check if the coverage result file exists
-          command: test -f /tmp/coverage/index.html
+          command: test -f /coverage/redmine_issue_templates_spec/index.html
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,17 +230,14 @@ jobs: # Integration Testing jobs
       - redmine-plugin/rspec:
           plugin: redmine_issue_templates
       - run:
-          name: Change directory to redmine directory
-          command: cd redmine
-      - run:
-          name: List contents of the current directory
-          command: ls -la
+          name: Print current working directory
+          command: pwd
       - run:
           name: Check if the test result file exists
           command: test -f /tmp/rspec/rspec.xml
       - run:
           name: Check if the coverage result file exists
-          command: test -f /redmine/coverage/redmine_issue_templates_spec/index.html
+          command: test -f project/redmine/coverage/redmine_issue_templates_spec/index.html
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.1.0
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.3
 
 # Pipeline parameters
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,11 +202,11 @@ jobs: # Integration Testing jobs
   test-bundle-install-without-Gemfile_local:
     executor:
       name: redmine-plugin/ruby-sqlite3
-      ruby_version: '2.6'
+      ruby_version: '$RUBY_MIN_VERSION'
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '4.1.5'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - run:
@@ -215,11 +215,11 @@ jobs: # Integration Testing jobs
   test-bundle-install-and-rspec:
     executor:
       name: redmine-plugin/ruby-sqlite3
-      ruby_version: '2.6'
+      ruby_version: '$RUBY_MIN_VERSION'
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '4.1.7'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/install-plugin:
           repository: git@github.com:agileware-jp/redmine_issue_templates.git
       - run:
@@ -238,11 +238,11 @@ jobs: # Integration Testing jobs
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3
-      ruby_version: '2.6'
+      ruby_version: '$RUBY_MIN_VERSION'
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '4.1.7'
+          version: '$REDMINE_MIN_VERSION'
       - redmine-plugin/install-plugin:
           repository: git@github.com:agileware-jp/redmine_issue_templates.git
       - run:
@@ -320,9 +320,15 @@ workflows:
       - test-install-plugin
       - test-install-self
       - test-generate-database_yml
-      - test-bundle-install-without-Gemfile_local
-      - test-bundle-install-and-rspec
-      - test-bundle-install-and-test
+      - test-bundle-install-without-Gemfile_local:
+          context:
+            - lychee-ci-environment
+      - test-bundle-install-and-rspec:
+          context:
+            - lychee-ci-environment
+      - test-bundle-install-and-test:
+          context:
+            - lychee-ci-environment
       - test-build-plugin-assets
       - test-build-plugin-assets-with-docker
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,11 @@ jobs: # Integration Testing jobs
       - run:
           name: Check if there is a .version file containing the specified version
           command: test "`cat redmine/.version`" = "3.4.9"
+      - run:
+          name: Install and set Chrome version
+          command: |
+            curl -sSL https://raw.githubusercontent.com/CircleCI-Public/browser-tools/v1.4.3/scripts/install-browser-tools | bash
+            circleci-browser install chrome 114.0.5735.90
   test-download-redmine-supported-min-version:
     executor: orb-tools/ubuntu
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs: # Integration Testing jobs
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:
-          version: '4.1.5'
+          version: '4.1.7'
       - redmine-plugin/install-plugin:
           repository: git@github.com:agileware-jp/redmine_github.git
       - run:
@@ -238,7 +238,7 @@ jobs: # Integration Testing jobs
   test-bundle-install-and-test:
     executor:
       name: redmine-plugin/ruby-sqlite3
-      ruby_version: '2.5'
+      ruby_version: '2.6'
     steps:
       - checkout # To resolve ssh problems with git later
       - redmine-plugin/download-redmine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,9 +230,6 @@ jobs: # Integration Testing jobs
       - redmine-plugin/rspec:
           plugin: redmine_issue_templates
       - run:
-          name: Print current working directory
-          command: pwd
-      - run:
           name: Check if the test result file exists
           command: test -f /tmp/rspec/rspec.xml
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,7 +228,7 @@ jobs: # Integration Testing jobs
       - redmine-plugin/generate-database_yml
       - redmine-plugin/bundle-install
       - redmine-plugin/rspec:
-          plugin: redmine_github
+          plugin: redmine_issue_templates
       - run:
           name: Check if the test result file exists
           command: test -f /tmp/rspec/rspec.xml

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.2

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.2
+  browser-tools: circleci/browser-tools@1.4.3

--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -29,7 +29,8 @@ parameters:
     default: ''
 
 steps:
-  - browser-tools/install-chrome
+  - browser-tools/install-chrome:
+      chrome-version: 114.0.5735.198
   - browser-tools/install-chromedriver
   - run:
       name: Setup Database

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -15,7 +15,8 @@ parameters:
     default: ''
 
 steps:
-  - browser-tools/install-chrome
+  - browser-tools/install-chrome:
+      chrome-version: 114.0.5735.198
   - browser-tools/install-chromedriver
   - run:
       name: Setup Database


### PR DESCRIPTION
Changed version from 1.4.1 to 1.4.3 because of an error due to a change in the chrome endpoint.

And, the latest version of chrome, 115.0.5790, cannot be installed, so 114.0.5735.198 must be specified.