### PR TITLE
Change the version of circleci/browser-tools to the latest 1.4.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.1.0
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6
 
 # Pipeline parameters
 parameters:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url:  https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6


### PR DESCRIPTION
Installation of ChromeDirver for new Chrome failed because of an older version of circleci/browser-tools.
The following version of Chrome failed.

* 116.0.5845.140

The following version of Chrome succeeds.

* 112.0.5615.49

You can update circleci/browser-tools to support the new Chrome, because the support for the new Chrome is included in circleci/browser-tools.