### PR TITLE
Uninstall system chrome before chrome installing

### DIFF
--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -27,11 +27,17 @@ parameters:
     description: Plugin name. If unspecified it will be the current repository's plugin.
     type: string
     default: ''
+  chrome_version:
+    type: string
+    default: '114.0.5735.198'
 
 steps:
   - run: sudo apt-get update
+  - run:
+      name: Uninstall pre-installed Chrome
+      command: sudo dpkg --purge google-chrome-stable
   - browser-tools/install-chrome:
-      chrome-version: 114.0.5735.198
+      chrome-version: '<< parameters.chrome_version >>'
   - browser-tools/install-chromedriver
   - run:
       name: Setup Database

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -13,10 +13,17 @@ parameters:
     description: Plugin name. If unspecified it will be the current repository's plugin.
     type: string
     default: ''
+  chrome_version:
+    type: string
+    default: '114.0.5735.198'
 
 steps:
+  - run: sudo apt-get update
+  - run:
+      name: Uninstall pre-installed Chrome
+      command: sudo dpkg --purge google-chrome-stable
   - browser-tools/install-chrome:
-      chrome-version: 114.0.5735.198
+      chrome-version: '<< parameters.chrome_version >>'
   - browser-tools/install-chromedriver
   - run:
       name: Setup Database


### PR DESCRIPTION
The process of uninstalling Chrome prior to installation in order to get a specific version of Chrome was done by individual plug-ins.
However, that would have scattered adhoc code in too many places, so I decided to use redmine-plugin-orb to handle it.

Also, the chrome version was always fixed, so we made it possible to specify it externally.