### PR TITLE
update browser-tools version [semver:patch]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   redmine-plugin: agileware-jp/redmine-plugin@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@9.1.0
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.0
 
 # Pipeline parameters
 parameters:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -9,4 +9,4 @@ display:
   source_url: https://github.com/agileware-jp/redmine-plugin-orb
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.8
+  browser-tools: circleci/browser-tools@1.5.0


### PR DESCRIPTION
circleci/browser-tools has been released version 1.5.0.
https://github.com/CircleCI-Public/browser-tools-orb/releases/tag/v1.5.0

This PR just followed the version update.