### PR TITLE
Fix for Bundler 4 [semver:patch]

### DIFF
--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -54,7 +54,8 @@ steps:
       working_directory: '<< parameters.redmine_root >>'
       command: |
         set -eux -o pipefail
-        bundle config set --local path vendor/bundle
+        # .bundle is in https://github.com/redmine/redmine/blob/6.1.0/.gitignore#L43
+        bundle config set --local path .bundle
         bundle install
   - when:
       condition: << parameters.update_packages >>
@@ -66,5 +67,5 @@ steps:
   - save_cache:
       key: '<< parameters.cache_key_prefix >>{{ checksum "/tmp/ruby-version" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile" }}-{{ checksum "<< parameters.redmine_root >>/Gemfile.local" }}-{{ checksum "<< parameters.redmine_root >>/config/database.yml" }}'
       paths:
-        - << parameters.redmine_root >>/vendor/bundle
+        - << parameters.redmine_root >>/.bundle
         - << parameters.redmine_root >>/Gemfile.lock

--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -52,7 +52,10 @@ steps:
   - run:
       name: Execute bundle install
       working_directory: '<< parameters.redmine_root >>'
-      command: bundle check --path vendor/bundle || bundle install --path vendor/bundle
+      command: |
+        set -eux -o pipefail
+        bundle config set --local path vendor/bundle
+        bundle install
   - when:
       condition: << parameters.update_packages >>
       steps:


### PR DESCRIPTION
`cimg/ruby:3.4.8` uses rubygems-4.0.2 and bundler-4.0.2 (difference from officially ruby-3.4.8).

```console
docker run -it cimg/ruby:3.4.8 bash -eux -o pipefail -c 'ruby -v && gem --version && bundle version'
+ ruby -v
ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [x86_64-linux]
+ gem --version
4.0.2
+ bundle version
4.0.2 (2025-12-17 commit 03359f8b08)
```

Bundler 4 dropped arguments on `bundle install`.

This pull-request follow those changes.
