### PR TITLE
Retry request for linux_signing_key.pub [semver:patch]

### DIFF
--- a/src/commands/bundle-install.yml
+++ b/src/commands/bundle-install.yml
@@ -30,8 +30,8 @@ steps:
   - run:
       name: key installation for chrome gpg key
       command: |
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
   - run:
       name: Install related packages
       command: |

--- a/src/commands/rspec.yml
+++ b/src/commands/rspec.yml
@@ -32,8 +32,8 @@ steps:
   - run:
       name: key installation for chrome gpg key
       command: |
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
   - run: sudo apt-get update
   - run:
       name: Uninstall pre-installed Chrome

--- a/src/commands/test.yml
+++ b/src/commands/test.yml
@@ -18,8 +18,8 @@ steps:
   - run:
       name: key installation for chrome gpg key
       command: |
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
-        wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | sudo tee /etc/apt/trusted.gpg.d/google.asc >/dev/null
+        curl -fsSL --retry 5 --retry-delay 10 --retry-connrefused --max-time 60 https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/google.gpg >/dev/null
   - run: sudo apt-get update
   - run:
       name: Uninstall pre-installed Chrome


### PR DESCRIPTION
Occasionally, `Exited with code exit status 8` occurs when fetching `linux_signing_key.pub`.
This change adds a retry mechanism to reduce the likelihood of this failure.